### PR TITLE
feat: add browser extension for apontamento site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # automacao-leega
+
+## Extensão de Automação
+
+O diretório `extension` contém uma extensão de navegador (manifesto v3) direcionada ao site de Apontamento da Leega. Para carregá-la no Chrome:
+
+1. Acesse `chrome://extensions/`.
+2. Habilite o **Modo do desenvolvedor**.
+3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
+
+A extensão injeta um script na página para auxiliar no preenchimento automático do campo de data.

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,10 @@
+console.log("Extensão carregada na página de Apontamento da Leega");
+
+// Preenche automaticamente o campo de data com a data atual, se existir
+(function () {
+  const dateInput = document.querySelector('input[type="date"]');
+  if (dateInput && !dateInput.value) {
+    const today = new Date().toISOString().split('T')[0];
+    dateInput.value = today;
+  }
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Automacao Apontamento Leega",
+  "version": "1.0",
+  "description": "Extensão para auxiliar no site de Apontamento da Leega",
+  "content_scripts": [
+    {
+      "matches": ["https://discovery.leega.com.br/Apontamento.aspx*"],
+      "js": ["content_script.js"]
+    }
+  ],
+  "permissions": ["storage"]
+}


### PR DESCRIPTION
## Summary
- add base Manifest V3 extension targeting Apontamento page
- include content script that fills date field and logs load event
- document how to load the extension in Chrome

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4378e94833086b5c6d2a8e29634