### PR TITLE
feat: add popup to list business days

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # automacao-leega
+
+## Extensão de Automação
+
+O diretório `extension` contém uma extensão de navegador (manifesto v3) direcionada ao site de Apontamento da Leega. Para carregá-la no Chrome:
+
+1. Acesse `chrome://extensions/`.
+2. Habilite o **Modo do desenvolvedor**.
+3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
+
+A extensão injeta um script na página para auxiliar no preenchimento automático do campo de data e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página.

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,16 @@
+console.log("Extensão carregada na página de Apontamento da Leega");
+
+// Preenche automaticamente o campo de data com a data atual, se existir
+(function () {
+  const dateInput = document.querySelector('input[type="date"]');
+  if (dateInput && !dateInput.value) {
+    const today = new Date().toISOString().split('T')[0];
+    dateInput.value = today;
+  }
+})();
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'LOG_BUSINESS_DAYS') {
+    console.log('Dias úteis do mês:', msg.payload);
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Automacao Apontamento Leega",
+  "version": "1.0",
+  "description": "Extensão para auxiliar no site de Apontamento da Leega",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://discovery.leega.com.br/Apontamento.aspx*"],
+      "js": ["content_script.js"]
+    }
+  ],
+  "permissions": ["storage", "tabs"]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Automação Leega</title>
+  </head>
+  <body>
+    <button id="businessDaysBtn">Listar dias úteis do mês</button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,26 @@
+function getBusinessDaysOfCurrentMonth() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth(); // 0-indexed
+  const date = new Date(year, month, 1);
+  const days = [];
+
+  while (date.getMonth() === month) {
+    const day = date.getDay();
+    if (day >= 1 && day <= 5) {
+      days.push(date.toISOString().split('T')[0]);
+    }
+    date.setDate(date.getDate() + 1);
+  }
+  return days;
+}
+
+document.getElementById('businessDaysBtn').addEventListener('click', () => {
+  const businessDays = getBusinessDaysOfCurrentMonth();
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, {
+      type: 'LOG_BUSINESS_DAYS',
+      payload: businessDays,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add popup button to list business days for current month
- handle popup click by logging weekdays to page console
- document popup usage in README

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4378e94833086b5c6d2a8e29634