### PR TITLE
feat: add popup to list business days

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 2. Habilite o **Modo do desenvolvedor**.
 3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
 
-A extensão injeta um script na página para auxiliar no preenchimento automático do campo de data e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página.
+A extensão injeta um script na página para auxiliar no preenchimento automático e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página e a primeira data é preenchida no formulário junto com o esforço (`08:00`) e o status (`99`).
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
 
 A extensão injeta um script na página para auxiliar no preenchimento automático do campo de data e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página.
+Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com os botões "Listar dias úteis do mês" e "Cadastrar Data" e, na própria página de Apontamento, um botão "Preencher Data" ao lado do campo de data.
 
 - Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
-- Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a primeira data útil do mês é inserida no campo de data e os campos de esforço (`08:00`) e status (`99`) são preenchidos automaticamente. O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
+- Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e insere a primeira data útil no campo de data, além de preencher automaticamente os campos de esforço (`08:00`) e status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
 
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A extensão injeta um script na página para auxiliar no preenchimento automáti
 
 - Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
 - Ao clicar em "Preencher mês" (no popup) ou "Preencher mês" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e percorre todas as datas, preenchendo os campos de data, esforço (`08:00`) e status (`99`) e clicando em "Salvar" para cada dia com uma pausa de aproximadamente dois segundos entre cada cadastro.
-
+- Após cada salvamento, os campos são buscados novamente para acompanhar os postbacks da página e evitar erros de validação.
 - O cálculo das datas considera o fuso horário local e o script tenta localizar os campos de esforço e status mesmo que os IDs variem (ex.: `CaixaEsforco`).
 
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 2. Habilite o **Modo do desenvolvedor**.
 3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
 
-A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com o botão "Listar dias úteis do mês" e, na própria página de Apontamento, um botão "Preencher Data" ao lado do campo de data.
+A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com os botões "Listar dias úteis do mês" e "Cadastrar Data" e, na própria página de Apontamento, um botão "Preencher Data" ao lado do campo de data.
 
 - Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
-- Ao clicar em "Preencher Data", a primeira data útil do mês é inserida no campo de data e os campos de esforço (`08:00`) e status (`99`) são preenchidos automaticamente. O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
+- Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a primeira data útil do mês é inserida no campo de data e os campos de esforço (`08:00`) e status (`99`) são preenchidos automaticamente. O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
 
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 2. Habilite o **Modo do desenvolvedor**.
 3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
 
-A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com os botões "Listar dias úteis do mês" e "Cadastrar Data" e, na própria página de Apontamento, um botão "Preencher Data" ao lado do campo de data.
+A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com os botões "Listar dias úteis do mês" e "Preencher mês" e, na própria página de Apontamento, um botão "Preencher mês" ao lado do campo de data.
 
 - Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
-- Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e insere a primeira data útil no campo de data, além de preencher automaticamente os campos de esforço (`08:00`) e status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa` e o botão "Salvar" é acionado automaticamente.
+- Ao clicar em "Preencher mês" (no popup) ou "Preencher mês" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e percorre todas as datas, preenchendo os campos de data, esforço (`08:00`) e status (`99`) e clicando em "Salvar" para cada dia com uma pausa de aproximadamente dois segundos entre cada cadastro.
 
 - O cálculo das datas considera o fuso horário local e o script tenta localizar os campos de esforço e status mesmo que os IDs variem (ex.: `CaixaEsforco`).
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # automacao-leega
+
+## Extensão de Automação
+
+O diretório `extension` contém uma extensão de navegador (manifesto v3) direcionada ao site de Apontamento da Leega. Para carregá-la no Chrome:
+
+1. Acesse `chrome://extensions/`.
+2. Habilite o **Modo do desenvolvedor**.
+3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
+
+A extensão injeta um script na página para auxiliar no preenchimento automático do campo de data e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página.

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 2. Habilite o **Modo do desenvolvedor**.
 3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
 
-A extensão injeta um script na página para auxiliar no preenchimento automático e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página e a primeira data é preenchida no formulário junto com o esforço (`08:00`) e o status (`99`).
+A extensão injeta um script na página para auxiliar no preenchimento automático e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página e a primeira data é preenchida no formulário junto com o esforço (`08:00`) e o status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com os botões "Listar dias úteis do mês" e "Cadastrar Data" e, na própria página de Apontamento, um botão "Preencher Data" ao lado do campo de data.
 
 - Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
-- Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e insere a primeira data útil no campo de data, além de preencher automaticamente os campos de esforço (`08:00`) e status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
+- Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e insere a primeira data útil no campo de data, além de preencher automaticamente os campos de esforço (`08:00`) e status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa` e o botão "Salvar" é acionado automaticamente.
 
 - O cálculo das datas considera o fuso horário local e o script tenta localizar os campos de esforço e status mesmo que os IDs variem (ex.: `CaixaEsforco`).
 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,9 @@ O diretório `extension` contém uma extensão de navegador (manifesto v3) direc
 2. Habilite o **Modo do desenvolvedor**.
 3. Clique em **Carregar sem empacotar** e selecione a pasta `extension`.
 
-A extensão injeta um script na página para auxiliar no preenchimento automático e oferece um **popup** com o botão "Listar dias úteis do mês". Ao clicar neste botão, as datas de segunda a sexta do mês corrente são exibidas no console da página e a primeira data é preenchida no formulário junto com o esforço (`08:00`) e o status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
+A extensão injeta um script na página para auxiliar no preenchimento automático. Ela oferece um **popup** com o botão "Listar dias úteis do mês" e, na própria página de Apontamento, um botão "Preencher Data" ao lado do campo de data.
+
+- Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
+- Ao clicar em "Preencher Data", a primeira data útil do mês é inserida no campo de data e os campos de esforço (`08:00`) e status (`99`) são preenchidos automaticamente. O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
+
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ A extensão injeta um script na página para auxiliar no preenchimento automáti
 - Ao clicar em "Listar dias úteis do mês", as datas de segunda a sexta do mês corrente são exibidas no console da página.
 - Ao clicar em "Cadastrar Data" (no popup) ou "Preencher Data" (na página), a extensão calcula os dias úteis do mês, envia a lista à página e insere a primeira data útil no campo de data, além de preencher automaticamente os campos de esforço (`08:00`) e status (`99`). O campo "Data" (`txtDataApontamento`) recebe a data no formato `dd/mm/aaaa`.
 
+- O cálculo das datas considera o fuso horário local e o script tenta localizar os campos de esforço e status mesmo que os IDs variem (ex.: `CaixaEsforco`).
+
 Se a aba ativa não estiver na página de Apontamento, uma mensagem de erro será registrada no console.

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,16 @@
+console.log("Extensão carregada na página de Apontamento da Leega");
+
+// Preenche automaticamente o campo de data com a data atual, se existir
+(function () {
+  const dateInput = document.querySelector('input[type="date"]');
+  if (dateInput && !dateInput.value) {
+    const today = new Date().toISOString().split('T')[0];
+    dateInput.value = today;
+  }
+})();
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'LOG_BUSINESS_DAYS') {
+    console.log('Dias úteis do mês:', msg.payload);
+  }
+});

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -60,6 +60,9 @@ function fillApontamento(days) {
   const statusField = document.getElementById(
     "ctl00_MainContent_ControleApontamento_CaixaStatus"
   );
+  const saveButton = document.getElementById(
+    "ctl00_MainContent_ControleApontamento_BotaoSalvar"
+  );
 
   if (dateField) {
     dateField.value = formatted;
@@ -78,6 +81,11 @@ function fillApontamento(days) {
     statusField.dispatchEvent(new Event("change", { bubbles: true }));
   } else {
     console.warn("Campo de status não encontrado");
+  }
+  if (saveButton) {
+    saveButton.click();
+  } else {
+    console.warn("Botão Salvar não encontrado");
   }
 }
 

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -35,3 +35,70 @@ chrome.runtime.onMessage.addListener((msg) => {
     }
   }
 });
+
+function getBusinessDaysOfCurrentMonth() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const date = new Date(year, month, 1);
+  const days = [];
+
+  while (date.getMonth() === month) {
+    const day = date.getDay();
+    if (day >= 1 && day <= 5) {
+      days.push(date.toISOString().split('T')[0]);
+    }
+    date.setDate(date.getDate() + 1);
+  }
+  return days;
+}
+
+function fillApontamento() {
+  const days = getBusinessDaysOfCurrentMonth();
+  console.log('Dias úteis do mês:', days);
+  const firstDay = days[0];
+  if (!firstDay) return;
+
+  const formatted = firstDay.split('-').reverse().join('/');
+  const dateField = document.getElementById(
+    'ctl00_MainContent_ControleApontamento_txtDataApontamento'
+  );
+  const effortField = document.getElementById(
+    'ctl00_MainContent_ControleApontamento_CaixaEsforço'
+  );
+  const statusField = document.getElementById(
+    'ctl00_MainContent_ControleApontamento_CaixaStatus'
+  );
+
+  if (dateField) {
+    dateField.value = formatted;
+    dateField.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+  if (effortField) {
+    effortField.value = '08:00';
+    effortField.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+  if (statusField) {
+    statusField.value = '99';
+    statusField.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}
+
+function insertFillButton() {
+  const dateField = document.getElementById(
+    'ctl00_MainContent_ControleApontamento_txtDataApontamento'
+  );
+  if (!dateField) return;
+
+  if (document.getElementById('fillDateBtn')) return;
+
+  const btn = document.createElement('button');
+  btn.id = 'fillDateBtn';
+  btn.type = 'button';
+  btn.textContent = 'Preencher Data';
+  btn.addEventListener('click', fillApontamento);
+
+  dateField.parentNode.appendChild(btn);
+}
+
+insertFillButton();

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -9,7 +9,8 @@ chrome.runtime.onMessage.addListener((msg) => {
   }
 
   if (msg.type === 'FILL_APONTAMENTO_DATE') {
-    fillApontamento();
+    const { days } = msg.payload || {};
+    fillApontamento(days);
   }
 });
 
@@ -30,10 +31,12 @@ function getBusinessDaysOfCurrentMonth() {
   return days;
 }
 
-function fillApontamento() {
-  const days = getBusinessDaysOfCurrentMonth();
-  console.log('Dias úteis do mês:', days);
-  const firstDay = days[0];
+function fillApontamento(days) {
+  const list = Array.isArray(days) ? days : getBusinessDaysOfCurrentMonth();
+  if (!Array.isArray(list) || list.length === 0) return;
+
+  console.log('Dias úteis do mês:', list);
+  const firstDay = list[0];
   if (!firstDay) return;
 
   const formatted = firstDay.split('-').reverse().join('/');
@@ -73,7 +76,7 @@ function insertFillButton() {
   btn.id = 'fillDateBtn';
   btn.type = 'button';
   btn.textContent = 'Preencher Data';
-  btn.addEventListener('click', fillApontamento);
+  btn.addEventListener('click', () => fillApontamento());
 
   dateField.parentNode.appendChild(btn);
 }

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -14,6 +14,13 @@ chrome.runtime.onMessage.addListener((msg) => {
   }
 });
 
+function formatISODate(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 function getBusinessDaysOfCurrentMonth() {
   const today = new Date();
   const year = today.getFullYear();
@@ -24,7 +31,7 @@ function getBusinessDaysOfCurrentMonth() {
   while (date.getMonth() === month) {
     const day = date.getDay();
     if (day >= 1 && day <= 5) {
-      days.push(date.toISOString().split('T')[0]);
+      days.push(formatISODate(date));
     }
     date.setDate(date.getDate() + 1);
   }
@@ -41,26 +48,36 @@ function fillApontamento(days) {
 
   const formatted = firstDay.split('-').reverse().join('/');
   const dateField = document.getElementById(
-    'ctl00_MainContent_ControleApontamento_txtDataApontamento'
+    "ctl00_MainContent_ControleApontamento_txtDataApontamento"
   );
-  const effortField = document.getElementById(
-    'ctl00_MainContent_ControleApontamento_CaixaEsforço'
-  );
+  const effortField =
+    document.getElementById(
+      "ctl00_MainContent_ControleApontamento_CaixaEsforço"
+    ) ||
+    document.getElementById(
+      "ctl00_MainContent_ControleApontamento_CaixaEsforco"
+    );
   const statusField = document.getElementById(
-    'ctl00_MainContent_ControleApontamento_CaixaStatus'
+    "ctl00_MainContent_ControleApontamento_CaixaStatus"
   );
 
   if (dateField) {
     dateField.value = formatted;
-    dateField.dispatchEvent(new Event('change', { bubbles: true }));
+    dateField.dispatchEvent(new Event("change", { bubbles: true }));
+  } else {
+    console.warn("Campo de data não encontrado");
   }
   if (effortField) {
-    effortField.value = '08:00';
-    effortField.dispatchEvent(new Event('change', { bubbles: true }));
+    effortField.value = "08:00";
+    effortField.dispatchEvent(new Event("change", { bubbles: true }));
+  } else {
+    console.warn("Campo de esforço não encontrado");
   }
   if (statusField) {
-    statusField.value = '99';
-    statusField.dispatchEvent(new Event('change', { bubbles: true }));
+    statusField.value = "99";
+    statusField.dispatchEvent(new Event("change", { bubbles: true }));
+  } else {
+    console.warn("Campo de status não encontrado");
   }
 }
 

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -38,15 +38,12 @@ function getBusinessDaysOfCurrentMonth() {
   return days;
 }
 
-function fillApontamento(days) {
+async function fillApontamento(days) {
   const list = Array.isArray(days) ? days : getBusinessDaysOfCurrentMonth();
   if (!Array.isArray(list) || list.length === 0) return;
 
   console.log('Dias úteis do mês:', list);
-  const firstDay = list[0];
-  if (!firstDay) return;
 
-  const formatted = firstDay.split('-').reverse().join('/');
   const dateField = document.getElementById(
     "ctl00_MainContent_ControleApontamento_txtDataApontamento"
   );
@@ -64,28 +61,38 @@ function fillApontamento(days) {
     "ctl00_MainContent_ControleApontamento_BotaoSalvar"
   );
 
-  if (dateField) {
+  if (!dateField) {
+    console.warn("Campo de data não encontrado");
+    return;
+  }
+  if (!effortField) {
+    console.warn("Campo de esforço não encontrado");
+    return;
+  }
+  if (!statusField) {
+    console.warn("Campo de status não encontrado");
+    return;
+  }
+  if (!saveButton) {
+    console.warn("Botão Salvar não encontrado");
+    return;
+  }
+
+  for (const isoDay of list) {
+    const formatted = isoDay.split('-').reverse().join('/');
+
     dateField.value = formatted;
     dateField.dispatchEvent(new Event("change", { bubbles: true }));
-  } else {
-    console.warn("Campo de data não encontrado");
-  }
-  if (effortField) {
+
     effortField.value = "08:00";
     effortField.dispatchEvent(new Event("change", { bubbles: true }));
-  } else {
-    console.warn("Campo de esforço não encontrado");
-  }
-  if (statusField) {
+
     statusField.value = "99";
     statusField.dispatchEvent(new Event("change", { bubbles: true }));
-  } else {
-    console.warn("Campo de status não encontrado");
-  }
-  if (saveButton) {
+
     saveButton.click();
-  } else {
-    console.warn("Botão Salvar não encontrado");
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 }
 
@@ -100,7 +107,7 @@ function insertFillButton() {
   const btn = document.createElement('button');
   btn.id = 'fillDateBtn';
   btn.type = 'button';
-  btn.textContent = 'Preencher Data';
+  btn.textContent = 'Preencher mês';
   btn.addEventListener('click', () => fillApontamento());
 
   dateField.parentNode.appendChild(btn);

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -44,56 +44,48 @@ async function fillApontamento(days) {
 
   console.log('Dias úteis do mês:', list);
 
-  const dateField = document.getElementById(
-    "ctl00_MainContent_ControleApontamento_txtDataApontamento"
-  );
-  const effortField =
-    document.getElementById(
-      "ctl00_MainContent_ControleApontamento_CaixaEsforço"
-    ) ||
-    document.getElementById(
-      "ctl00_MainContent_ControleApontamento_CaixaEsforco"
-    );
-  const statusField = document.getElementById(
-    "ctl00_MainContent_ControleApontamento_CaixaStatus"
-  );
-  const saveButton = document.getElementById(
-    "ctl00_MainContent_ControleApontamento_BotaoSalvar"
-  );
-
-  if (!dateField) {
-    console.warn("Campo de data não encontrado");
-    return;
-  }
-  if (!effortField) {
-    console.warn("Campo de esforço não encontrado");
-    return;
-  }
-  if (!statusField) {
-    console.warn("Campo de status não encontrado");
-    return;
-  }
-  if (!saveButton) {
-    console.warn("Botão Salvar não encontrado");
-    return;
-  }
-
   for (const isoDay of list) {
     const formatted = isoDay.split('-').reverse().join('/');
 
+    const dateField = await waitForElement(
+      'ctl00_MainContent_ControleApontamento_txtDataApontamento'
+    );
+    const effortField =
+      (await waitForElement(
+        'ctl00_MainContent_ControleApontamento_CaixaEsforço'
+      )) ||
+      (await waitForElement(
+        'ctl00_MainContent_ControleApontamento_CaixaEsforco'
+      ));
+    const statusField = await waitForElement(
+      'ctl00_MainContent_ControleApontamento_CaixaStatus'
+    );
+    const saveButton = await waitForElement(
+      'ctl00_MainContent_ControleApontamento_BotaoSalvar'
+    );
+
+    if (!dateField || !effortField || !statusField || !saveButton) {
+      console.warn('Algum campo não foi encontrado, interrompendo');
+      return;
+    }
+
     dateField.value = formatted;
-    dateField.dispatchEvent(new Event("change", { bubbles: true }));
-
-    effortField.value = "08:00";
-    effortField.dispatchEvent(new Event("change", { bubbles: true }));
-
-    statusField.value = "99";
-    statusField.dispatchEvent(new Event("change", { bubbles: true }));
-
+    effortField.value = '08:00';
+    statusField.value = '99';
     saveButton.click();
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
   }
+}
+
+async function waitForElement(id, timeout = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const el = document.getElementById(id);
+    if (el) return el;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return null;
 }
 
 function insertFillButton() {

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,16 +1,25 @@
 console.log("Extensão carregada na página de Apontamento da Leega");
 
-// Preenche automaticamente o campo de data com a data atual, se existir
-(function () {
-  const dateInput = document.querySelector('input[type="date"]');
-  if (dateInput && !dateInput.value) {
-    const today = new Date().toISOString().split('T')[0];
-    dateInput.value = today;
-  }
-})();
-
 chrome.runtime.onMessage.addListener((msg) => {
   if (msg.type === 'LOG_BUSINESS_DAYS') {
     console.log('Dias úteis do mês:', msg.payload);
+
+    const firstDay = msg.payload && msg.payload[0];
+    if (firstDay) {
+      const formatted = firstDay.split('-').reverse().join('/');
+      const dateField = document.getElementById(
+        'ctl00_MainContent_ControleApontamento_txtDataApontamento'
+      );
+      const effortField = document.getElementById(
+        'ctl00_MainContent_ControleApontamento_CaixaEsforço'
+      );
+      const statusField = document.getElementById(
+        'ctl00_MainContent_ControleApontamento_CaixaStatus'
+      );
+
+      if (dateField) dateField.value = formatted;
+      if (effortField) effortField.value = '08:00';
+      if (statusField) statusField.value = '99';
+    }
   }
 });

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,38 +1,15 @@
 console.log("Extensão carregada na página de Apontamento da Leega");
 
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.type === 'FILL_APONTAMENTO_DATE') {
-    const { firstDay, days } = msg.payload || {};
-
+  if (msg.type === 'LIST_BUSINESS_DAYS') {
+    const { days } = msg.payload || {};
     if (Array.isArray(days)) {
       console.log('Dias úteis do mês:', days);
     }
+  }
 
-    if (firstDay) {
-      const formatted = firstDay.split('-').reverse().join('/');
-      const dateField = document.getElementById(
-        'ctl00_MainContent_ControleApontamento_txtDataApontamento'
-      );
-      const effortField = document.getElementById(
-        'ctl00_MainContent_ControleApontamento_CaixaEsforço'
-      );
-      const statusField = document.getElementById(
-        'ctl00_MainContent_ControleApontamento_CaixaStatus'
-      );
-
-      if (dateField) {
-        dateField.value = formatted;
-        dateField.dispatchEvent(new Event('change', { bubbles: true }));
-      }
-      if (effortField) {
-        effortField.value = '08:00';
-        effortField.dispatchEvent(new Event('change', { bubbles: true }));
-      }
-      if (statusField) {
-        statusField.value = '99';
-        statusField.dispatchEvent(new Event('change', { bubbles: true }));
-      }
-    }
+  if (msg.type === 'FILL_APONTAMENTO_DATE') {
+    fillApontamento();
   }
 });
 

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,10 +1,13 @@
 console.log("Extensão carregada na página de Apontamento da Leega");
 
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.type === 'LOG_BUSINESS_DAYS') {
-    console.log('Dias úteis do mês:', msg.payload);
+  if (msg.type === 'FILL_APONTAMENTO_DATE') {
+    const { firstDay, days } = msg.payload || {};
 
-    const firstDay = msg.payload && msg.payload[0];
+    if (Array.isArray(days)) {
+      console.log('Dias úteis do mês:', days);
+    }
+
     if (firstDay) {
       const formatted = firstDay.split('-').reverse().join('/');
       const dateField = document.getElementById(
@@ -17,9 +20,18 @@ chrome.runtime.onMessage.addListener((msg) => {
         'ctl00_MainContent_ControleApontamento_CaixaStatus'
       );
 
-      if (dateField) dateField.value = formatted;
-      if (effortField) effortField.value = '08:00';
-      if (statusField) statusField.value = '99';
+      if (dateField) {
+        dateField.value = formatted;
+        dateField.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      if (effortField) {
+        effortField.value = '08:00';
+        effortField.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      if (statusField) {
+        statusField.value = '99';
+        statusField.dispatchEvent(new Event('change', { bubbles: true }));
+      }
     }
   }
 });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Automacao Apontamento Leega",
+  "version": "1.0",
+  "description": "Extensão para auxiliar no site de Apontamento da Leega",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://discovery.leega.com.br/Apontamento.aspx*"],
+      "js": ["content_script.js"]
+    }
+  ],
+  "permissions": ["storage", "tabs"]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <button id="businessDaysBtn">Listar dias úteis do mês</button>
+    <button id="fillDatePopupBtn">Cadastrar Data</button>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Automação Leega</title>
+  </head>
+  <body>
+    <button id="businessDaysBtn">Listar dias úteis do mês</button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <button id="businessDaysBtn">Listar dias úteis do mês</button>
-    <button id="fillDatePopupBtn">Cadastrar Data</button>
+    <button id="fillDatePopupBtn">Preencher mês</button>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -17,7 +17,6 @@ function getBusinessDaysOfCurrentMonth() {
 
 document.getElementById('businessDaysBtn').addEventListener('click', async () => {
   const businessDays = getBusinessDaysOfCurrentMonth();
-  const firstDay = businessDays[0];
 
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -27,10 +26,26 @@ document.getElementById('businessDaysBtn').addEventListener('click', async () =>
     }
 
     await chrome.tabs.sendMessage(tab.id, {
-      type: 'FILL_APONTAMENTO_DATE',
-      payload: { firstDay, days: businessDays },
+      type: 'LIST_BUSINESS_DAYS',
+      payload: { days: businessDays },
     });
   } catch (err) {
     console.error('Conteúdo não disponível na aba atual:', err.message);
   }
 });
+
+document
+  .getElementById('fillDatePopupBtn')
+  .addEventListener('click', async () => {
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!tab?.id) {
+        console.error('Nenhuma aba ativa encontrada');
+        return;
+      }
+
+      await chrome.tabs.sendMessage(tab.id, { type: 'FILL_APONTAMENTO_DATE' });
+    } catch (err) {
+      console.error('Conteúdo não disponível na aba atual:', err.message);
+    }
+  });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -18,9 +18,20 @@ function getBusinessDaysOfCurrentMonth() {
 document.getElementById('businessDaysBtn').addEventListener('click', () => {
   const businessDays = getBusinessDaysOfCurrentMonth();
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    chrome.tabs.sendMessage(tabs[0].id, {
-      type: 'LOG_BUSINESS_DAYS',
-      payload: businessDays,
-    });
+    chrome.tabs.sendMessage(
+      tabs[0].id,
+      {
+        type: 'LOG_BUSINESS_DAYS',
+        payload: businessDays,
+      },
+      () => {
+        if (chrome.runtime.lastError) {
+          console.error(
+            'Conteúdo não disponível na aba atual:',
+            chrome.runtime.lastError.message
+          );
+        }
+      }
+    );
   });
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -37,6 +37,8 @@ document.getElementById('businessDaysBtn').addEventListener('click', async () =>
 document
   .getElementById('fillDatePopupBtn')
   .addEventListener('click', async () => {
+    const businessDays = getBusinessDaysOfCurrentMonth();
+
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       if (!tab?.id) {
@@ -44,7 +46,10 @@ document
         return;
       }
 
-      await chrome.tabs.sendMessage(tab.id, { type: 'FILL_APONTAMENTO_DATE' });
+      await chrome.tabs.sendMessage(tab.id, {
+        type: 'FILL_APONTAMENTO_DATE',
+        payload: { days: businessDays },
+      });
     } catch (err) {
       console.error('Conteúdo não disponível na aba atual:', err.message);
     }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -17,6 +17,8 @@ function getBusinessDaysOfCurrentMonth() {
 
 document.getElementById('businessDaysBtn').addEventListener('click', async () => {
   const businessDays = getBusinessDaysOfCurrentMonth();
+  const firstDay = businessDays[0];
+
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (!tab?.id) {
@@ -25,8 +27,8 @@ document.getElementById('businessDaysBtn').addEventListener('click', async () =>
     }
 
     await chrome.tabs.sendMessage(tab.id, {
-      type: 'LOG_BUSINESS_DAYS',
-      payload: businessDays,
+      type: 'FILL_APONTAMENTO_DATE',
+      payload: { firstDay, days: businessDays },
     });
   } catch (err) {
     console.error('Conteúdo não disponível na aba atual:', err.message);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -15,23 +15,20 @@ function getBusinessDaysOfCurrentMonth() {
   return days;
 }
 
-document.getElementById('businessDaysBtn').addEventListener('click', () => {
+document.getElementById('businessDaysBtn').addEventListener('click', async () => {
   const businessDays = getBusinessDaysOfCurrentMonth();
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    chrome.tabs.sendMessage(
-      tabs[0].id,
-      {
-        type: 'LOG_BUSINESS_DAYS',
-        payload: businessDays,
-      },
-      () => {
-        if (chrome.runtime.lastError) {
-          console.error(
-            'Conteúdo não disponível na aba atual:',
-            chrome.runtime.lastError.message
-          );
-        }
-      }
-    );
-  });
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) {
+      console.error('Nenhuma aba ativa encontrada');
+      return;
+    }
+
+    await chrome.tabs.sendMessage(tab.id, {
+      type: 'LOG_BUSINESS_DAYS',
+      payload: businessDays,
+    });
+  } catch (err) {
+    console.error('Conteúdo não disponível na aba atual:', err.message);
+  }
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,3 +1,10 @@
+function formatISODate(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 function getBusinessDaysOfCurrentMonth() {
   const today = new Date();
   const year = today.getFullYear();
@@ -8,7 +15,7 @@ function getBusinessDaysOfCurrentMonth() {
   while (date.getMonth() === month) {
     const day = date.getDay();
     if (day >= 1 && day <= 5) {
-      days.push(date.toISOString().split('T')[0]);
+      days.push(formatISODate(date));
     }
     date.setDate(date.getDate() + 1);
   }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,26 @@
+function getBusinessDaysOfCurrentMonth() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth(); // 0-indexed
+  const date = new Date(year, month, 1);
+  const days = [];
+
+  while (date.getMonth() === month) {
+    const day = date.getDay();
+    if (day >= 1 && day <= 5) {
+      days.push(date.toISOString().split('T')[0]);
+    }
+    date.setDate(date.getDate() + 1);
+  }
+  return days;
+}
+
+document.getElementById('businessDaysBtn').addEventListener('click', () => {
+  const businessDays = getBusinessDaysOfCurrentMonth();
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, {
+      type: 'LOG_BUSINESS_DAYS',
+      payload: businessDays,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add popup button to list business days for current month
- handle popup click by logging weekdays to page console
- document popup usage in README

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4378e94833086b5c6d2a8e29634